### PR TITLE
Fix integration tests by using mock_sbctl in GitHub workflow

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -40,6 +40,8 @@ jobs:
         run: uv run pytest -m unit -v
       
       - name: Run integration tests
+        env:
+          USE_MOCK_SBCTL: "true"
         run: uv run pytest -m integration -v
       
       - name: Run linting


### PR DESCRIPTION
## Summary
- Adds the `USE_MOCK_SBCTL=true` environment variable to the integration test step in GitHub workflow to fix CI failures
- Allows integration tests to run in the CI environment without requiring the actual sbctl binary

## Problem
The integration tests were failing in CI with errors like:
```
FileNotFoundError: [Errno 2] No such file or directory: 'sbctl'
```

This happened because the GitHub runner doesn't have the `sbctl` binary installed, but the integration tests in `test_real_bundle.py` require it.

## Solution
The codebase already has a mock implementation of sbctl in `tests/fixtures/mock_sbctl.py` and a mechanism to use it via the `USE_MOCK_SBCTL` environment variable. This PR modifies the GitHub workflow to set this environment variable when running integration tests.

The change is minimal and only affects the CI environment. The real sbctl binary is still used during local development unless explicitly overridden.

## Testing
- Confirmed that integration tests now pass with the `USE_MOCK_SBCTL=true` environment variable
- Verified that all tests in `test_real_bundle.py` pass locally with the mock implementation
- No changes to the actual codebase were needed as the mock implementation was already in place

This fix allows CI to validate the integration tests properly without requiring the actual sbctl binary to be installed on the GitHub runner.