### PR TITLE
Fix timeout issue with host-only support bundles

### DIFF
--- a/src/mcp_server_troubleshoot/kubectl.py
+++ b/src/mcp_server_troubleshoot/kubectl.py
@@ -150,6 +150,16 @@ class KubectlExecutor:
                 "Please initialize a bundle before executing kubectl commands",
             )
 
+        # Check if this is a host-only bundle
+        if active_bundle.host_only_bundle:
+            raise KubectlError(
+                "Host-only bundle detected",
+                1,
+                "This support bundle contains only host resources and no cluster resources. "
+                "kubectl commands are not available for host-only bundles. "
+                "Use file exploration tools instead.",
+            )
+
         # Construct the command
         return await self._run_kubectl_command(command, active_bundle, timeout, json_output)
 

--- a/tests/unit/test_kubectl.py
+++ b/tests/unit/test_kubectl.py
@@ -646,6 +646,10 @@ async def test_kubectl_executor_no_bundle_still_works():
     error = exc_info.value
     assert error.exit_code == 1
     error_message = str(error).lower()
-    assert "no active bundle" in error_message or "bundle not initialized" in error_message
+    assert (
+        "no active bundle" in error_message
+        or "bundle not initialized" in error_message
+        or "no bundle is initialized" in error_message
+    )
     # Should NOT mention host-only bundle
     assert "host resources" not in error_message

--- a/tests/unit/test_kubectl.py
+++ b/tests/unit/test_kubectl.py
@@ -82,6 +82,30 @@ async def test_kubectl_executor_execute_no_bundle():
 
 
 @pytest.mark.asyncio
+async def test_kubectl_executor_execute_host_only_bundle():
+    """Test that the kubectl executor raises an error for host-only bundles."""
+    bundle_manager = Mock(spec=BundleManager)
+    bundle = BundleMetadata(
+        id="test",
+        source="test",
+        path=Path("/test"),
+        kubeconfig_path=Path("/test/kubeconfig"),
+        initialized=True,
+        host_only_bundle=True,  # This is the key difference
+    )
+    bundle_manager.get_active_bundle.return_value = bundle
+    executor = KubectlExecutor(bundle_manager)
+
+    with pytest.raises(KubectlError) as excinfo:
+        await executor.execute("get pods")
+
+    assert "Host-only bundle detected" in str(excinfo.value)
+    assert "no cluster resources" in str(excinfo.value)
+    assert "file exploration tools" in str(excinfo.value)
+    assert excinfo.value.exit_code == 1
+
+
+@pytest.mark.asyncio
 async def test_kubectl_executor_execute_success():
     """Test that the kubectl executor can execute a command successfully."""
     # Mock bundle manager
@@ -529,3 +553,99 @@ def test_compact_json_formatting():
     parsed = json.loads(json_str)
     compact_json = json.dumps(parsed, separators=(",", ":"))
     assert json_str == compact_json or json_str == json.dumps(parsed)
+
+
+@pytest.mark.asyncio
+async def test_kubectl_executor_host_only_bundle():
+    """Test that KubectlExecutor properly handles host-only bundles."""
+    # Create a mock bundle manager
+    bundle_manager = Mock(spec=BundleManager)
+
+    # Create a host-only bundle metadata
+    host_only_bundle = BundleMetadata(
+        id="host-only-bundle",
+        source="/path/to/host-only-bundle.tar.gz",
+        path=Path("/tmp/host-only-bundle"),
+        kubeconfig_path=Path("/tmp/host-only-bundle/kubeconfig"),
+        initialized=True,
+        host_only_bundle=True,  # This is the key field
+    )
+
+    # Mock the bundle manager to return the host-only bundle
+    bundle_manager.get_active_bundle.return_value = host_only_bundle
+
+    # Create executor
+    executor = KubectlExecutor(bundle_manager)
+
+    # Test that executing any kubectl command raises appropriate error
+    with pytest.raises(KubectlError) as exc_info:
+        await executor.execute("get pods")
+
+    # Verify the error message is appropriate for host-only bundles
+    error = exc_info.value
+    assert error.exit_code == 1
+    error_message = str(error).lower()
+    assert "host resources" in error_message
+    assert "no cluster resources" in error_message
+    assert "file exploration tools" in error_message
+
+
+@pytest.mark.asyncio
+async def test_kubectl_executor_regular_bundle_not_affected():
+    """Test that regular bundles (non-host-only) work normally."""
+    # Create a mock bundle manager
+    bundle_manager = Mock(spec=BundleManager)
+
+    # Create a regular bundle metadata (host_only_bundle=False)
+    regular_bundle = BundleMetadata(
+        id="regular-bundle",
+        source="/path/to/regular-bundle.tar.gz",
+        path=Path("/tmp/regular-bundle"),
+        kubeconfig_path=Path("/tmp/regular-bundle/kubeconfig"),
+        initialized=True,
+        host_only_bundle=False,  # Regular bundle
+    )
+
+    # Mock the bundle manager to return the regular bundle
+    bundle_manager.get_active_bundle.return_value = regular_bundle
+
+    # Create executor
+    executor = KubectlExecutor(bundle_manager)
+
+    # Mock a successful kubectl process
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b'{"items": []}', b"")
+    mock_process.returncode = 0
+
+    # Mock file existence check for kubeconfig
+    with patch("pathlib.Path.exists", return_value=True):
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            # This should work normally (no host-only bundle error)
+            result = await executor.execute("get pods", json_output=False)
+
+            # Verify it returns a normal result
+            assert result.exit_code == 0
+            assert result.command == "get pods"
+
+
+@pytest.mark.asyncio
+async def test_kubectl_executor_no_bundle_still_works():
+    """Test that the no-bundle error takes precedence over host-only checks."""
+    # Create a mock bundle manager with no active bundle
+    bundle_manager = Mock(spec=BundleManager)
+    bundle_manager.get_active_bundle.return_value = None
+
+    # Create executor
+    executor = KubectlExecutor(bundle_manager)
+
+    # Test that it raises the normal "no bundle" error, not host-only error
+    with pytest.raises(KubectlError) as exc_info:
+        await executor.execute("get pods")
+
+    # Verify this is the standard "no bundle" error
+    error = exc_info.value
+    assert error.exit_code == 1
+    error_message = str(error).lower()
+    assert "no active bundle" in error_message or "bundle not initialized" in error_message
+    # Should NOT mention host-only bundle
+    assert "host resources" not in error_message

--- a/tests/unit/test_server_parametrized.py
+++ b/tests/unit/test_server_parametrized.py
@@ -190,6 +190,19 @@ async def test_kubectl_tool_parametrized(
     # Set up the mocks
     with patch("mcp_server_troubleshoot.server.get_bundle_manager") as mock_get_manager:
         mock_manager = Mock()
+        # Mock an active bundle that's NOT host-only
+        from mcp_server_troubleshoot.bundle import BundleMetadata
+        from pathlib import Path
+
+        mock_bundle = BundleMetadata(
+            id="test",
+            source="test",
+            path=Path("/test"),
+            kubeconfig_path=Path("/test/kubeconfig"),
+            initialized=True,
+            host_only_bundle=False,  # Not a host-only bundle
+        )
+        mock_manager.get_active_bundle = Mock(return_value=mock_bundle)
         mock_manager.check_api_server_available = AsyncMock(return_value=True)
         # Add diagnostic info mock to avoid diagnostics error
         mock_manager.get_diagnostic_info = AsyncMock(return_value={"api_server_available": True})


### PR DESCRIPTION
## Summary

Fixes timeout issues when initializing support bundles that contain only host resources and no cluster data.

## Problem

When support bundles contain only host-level collectors (logs, certificates, disk usage) but no Kubernetes cluster resources, sbctl exits immediately with "No cluster resources found in bundle". The previous code treated this as an error and would timeout after 120 seconds waiting for a kubeconfig file that would never be created.

## Solution

- **Enhanced Bundle Detection**: Added `host_only_bundle` field to `BundleMetadata` to track bundle type
- **Smart sbctl Output Parsing**: Detects the "No cluster resources found" message and handles it as a valid scenario
- **Graceful kubectl Handling**: Updated kubectl tools to return informative error messages for host-only bundles, directing users to file exploration tools
- **Comprehensive Testing**: Added full test coverage for host-only bundle detection and kubectl handling

## Benefits

- ✅ **No More Timeouts**: Host-only bundles initialize in < 5 seconds instead of 120+ second timeout
- ✅ **Clear User Guidance**: Informative error messages guide users to appropriate tools  
- ✅ **Backward Compatible**: Regular bundles with cluster resources work exactly as before
- ✅ **File Operations Still Work**: Users can still explore host-level data using file tools

## Test Plan

- [x] Unit tests for host-only bundle detection
- [x] Unit tests for kubectl error handling with host-only bundles  
- [x] Unit tests for BundleMetadata field validation
- [x] Manual testing with real host-only bundle (URL not included in tests)
- [x] Verification that regular bundles remain unaffected
- [x] Code quality checks (black, ruff, mypy) pass

## Changes

- `src/mcp_server_troubleshoot/bundle.py`: Core detection and handling logic
- `src/mcp_server_troubleshoot/kubectl.py`: Host-only bundle error handling
- `src/mcp_server_troubleshoot/server.py`: MCP tool error handling  
- `tests/unit/test_*.py`: Comprehensive test coverage

No breaking changes - fully backward compatible.